### PR TITLE
Fix fixed timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,29 +41,46 @@ func main() {
 
 	fmt.Println("## UTC")
 	fmt.Println(utc)
-	fmt.Println("## UTC -> JST (current timezone)")
+	fmt.Println("## UTC -> current timezone")
 	fmt.Println(jst)
 
 	var est time.Time
 	est, _ = timezone.FixedTimezone(now, "America/New_York")
-	fmt.Println("## JST -> EST")
+	fmt.Println("## current timezone -> EDT")
 	fmt.Println(est)
 }
 ```
 
 ### Result
 
-```
+```console
+# current timezone = UTC
+$ TZ=UTC go run /path/to/main.go
 32400 <nil>
 0 Invalid short timezone: hogehoge
 [Antarctica/Troll Etc/UTC Etc/Universal Etc/Zulu UTC Universal Zulu] <nil>
 [] Invalid short timezone: foobar
 ## current timezone
-2016-03-02 14:33:49.078798783 +0900 JST
+2018-03-15 00:07:01.921041165 +0000 UTC m=+0.000669042
 ## UTC
-2016-03-02 05:33:49.078798783 +0000 UTC
-## UTC -> JST (current timezone)
-2016-03-02 14:33:49.078798783 +0900 JST
-## JST -> EST
-2016-03-02 00:33:49.078798783 -0500 EST
+2018-03-15 00:07:01.921041165 +0000 UTC
+## UTC -> current timezone
+2018-03-15 00:07:01.921041165 +0000 UTC
+## current timezone -> EDT
+2018-03-14 20:07:01.921041165 -0400 EDT
+
+# current timezone = JST
+$ TZ=Asia/Tokyo go run /path/to/main.go
+32400 <nil>
+0 Invalid short timezone: hogehoge
+[Antarctica/Troll Etc/UTC Etc/Universal Etc/Zulu UTC Universal Zulu] <nil>
+[] Invalid short timezone: foobar
+## current timezone
+2018-03-15 09:08:58.410680998 +0900 JST m=+0.000536318
+## UTC
+2018-03-15 00:08:58.410680998 +0000 UTC
+## UTC -> current timezone
+2018-03-15 09:08:58.410680998 +0900 JST
+## current timezone -> EDT
+2018-03-14 20:08:58.410680998 -0400 EDT
 ```

--- a/timezone.go
+++ b/timezone.go
@@ -1145,10 +1145,6 @@ func FixedTimezone(t time.Time, timezone string) (time.Time, error) {
 	var loc *time.Location
 	zone, offset := time.Now().In(time.Local).Zone()
 
-	if zone == "UTC" {
-		return t, err
-	}
-
 	if timezone != "" {
 		loc, err = time.LoadLocation(timezone)
 		if err != nil {


### PR DESCRIPTION
ref https://github.com/tkuchiki/go-timezone/issues/4

```console
# current timezone = UTC
$ TZ=UTC go run /path/to/main.go
32400 <nil>
0 Invalid short timezone: hogehoge
[Antarctica/Troll Etc/UTC Etc/Universal Etc/Zulu UTC Universal Zulu] <nil>
[] Invalid short timezone: foobar
## current timezone
2018-03-15 00:07:01.921041165 +0000 UTC m=+0.000669042
## UTC
2018-03-15 00:07:01.921041165 +0000 UTC
## UTC -> current timezone
2018-03-15 00:07:01.921041165 +0000 UTC
## current timezone -> EDT
2018-03-14 20:07:01.921041165 -0400 EDT

# current timezone = JST
$ TZ=Asia/Tokyo go run /path/to/main.go
32400 <nil>
0 Invalid short timezone: hogehoge
[Antarctica/Troll Etc/UTC Etc/Universal Etc/Zulu UTC Universal Zulu] <nil>
[] Invalid short timezone: foobar
## current timezone
2018-03-15 09:08:58.410680998 +0900 JST m=+0.000536318
## UTC
2018-03-15 00:08:58.410680998 +0000 UTC
## UTC -> current timezone
2018-03-15 09:08:58.410680998 +0900 JST
## current timezone -> EDT
2018-03-14 20:08:58.410680998 -0400 EDT
```