### PR TITLE
Change Pacific Time to UTC-8

### DIFF
--- a/tz_abbr_infos.go
+++ b/tz_abbr_infos.go
@@ -520,7 +520,7 @@ var tzAbbrInfos = map[string][]*TzAbbreviationInfo{
 			isDST:       false,
 			name:        "Pacific Standard Time",
 			offset:      -25200,
-			offsetHHMM:  "-07:00",
+			offsetHHMM:  "-08:00",
 		},
 		{
 			countryCode: "PN",

--- a/tz_abbr_infos.go
+++ b/tz_abbr_infos.go
@@ -519,7 +519,7 @@ var tzAbbrInfos = map[string][]*TzAbbreviationInfo{
 			countryCode: "CA",
 			isDST:       false,
 			name:        "Pacific Standard Time",
-			offset:      -25200,
+			offset:      -28800,
 			offsetHHMM:  "-08:00",
 		},
 		{


### PR DESCRIPTION
This seems to be incorrect. Pacific Time both in the US and Canada is UTC-8, not -7

https://www.timeanddate.com/worldclock/canada
https://www.timeanddate.com/time/zone/usa/los-angeles